### PR TITLE
Ignore weekends

### DIFF
--- a/check-wait-label/README.md
+++ b/check-wait-label/README.md
@@ -1,6 +1,6 @@
 # Check Wait Label
 
-Checks PRs on a repo for a waiting label, and if found checks if the `wait_time` has passed.  If enough time has passed, remove the `wait_label` and add the `done_waiting_label`.
+Checks PRs on a repo for a waiting label, and if found checks if the `wait_time` has passed.  If enough time has passed, remove the `wait_label` and add the `done_waiting_label`.  The calculation excludes weekend days from the wait time.
 
 ## Inputs
 

--- a/check-wait-label/dist/index.js
+++ b/check-wait-label/dist/index.js
@@ -2003,12 +2003,27 @@ async function applyLabel(octokit, repo, issue_number, newLabel) {
 	})
 }
 
+function getWeekendDaysCount(startDate, endDate) {
+  let count = 0;
+  let curDate = startDate;
+  while (curDate <= endDate) {
+    var dayOfWeek = curDate.getDay();
+    if ((dayOfWeek == 6) || (dayOfWeek == 0)) {
+		  count++
+		}
+
+		curDate.setDate(curDate.getDate() + 1);
+  }
+  return count;
+}
+
 
 module.exports = {
 	getPrTime,
 	applyLabel,
 	removeLabel,
-	getPrIds
+	getPrIds,
+	getWeekendDaysCount
 }
 
 
@@ -3847,7 +3862,7 @@ isStream.transform = function (stream) {
 
 const core = __webpack_require__(470);
 const { context, GitHub } = __webpack_require__(469);
-const { getPrTime, applyLabel, removeLabel, getPrIds } = __webpack_require__(278);
+const { getPrTime, applyLabel, removeLabel, getPrIds, getWeekendDaysCount } = __webpack_require__(278);
 
 async function run() {
   try {
@@ -3865,7 +3880,9 @@ async function run() {
       let number = prs[i]
       let prTime = await getPrTime(octokit, repo, number)
       let nowTime = Date.now()
-      let timeWaited = (nowTime - prTime) / 24 / 60 / 60 / 1000
+      let timeElapsed = (nowTime - prTime) / 24 / 60 / 60 / 1000
+      let numWeekend = getWeekendDaysCount(prTime, nowTime)
+      let timeWaited = timeElapsed - numWeekend
 
       if (timeWaited - waitTime >= 0) {
         await applyLabel(octokit, repo, number, doneLabel)

--- a/check-wait-label/dist/index.js
+++ b/check-wait-label/dist/index.js
@@ -1977,7 +1977,8 @@ async function getPrTime(octokit, repo, issue_number) {
     ...repo,
     issue_number
   });
-  return Date.parse(issue.created_at);
+	let create_time = new Date(issue.created_at)
+  return create_time
 }
 
 async function removeLabel(octokit, repo, issue_number, oldLabel) {
@@ -3879,7 +3880,7 @@ async function run() {
     for (const i in prs) {
       let number = prs[i]
       let prTime = await getPrTime(octokit, repo, number)
-      let nowTime = Date.now()
+      let nowTime = new Date(Date.now())
       let timeElapsed = (nowTime - prTime) / 24 / 60 / 60 / 1000
       let numWeekend = getWeekendDaysCount(prTime, nowTime)
       let timeWaited = timeElapsed - numWeekend

--- a/check-wait-label/main.js
+++ b/check-wait-label/main.js
@@ -17,7 +17,7 @@ async function run() {
     for (const i in prs) {
       let number = prs[i]
       let prTime = await getPrTime(octokit, repo, number)
-      let nowTime = Date.now()
+      let nowTime = new Date(Date.now())
       let timeElapsed = (nowTime - prTime) / 24 / 60 / 60 / 1000
       let numWeekend = getWeekendDaysCount(prTime, nowTime)
       let timeWaited = timeElapsed - numWeekend

--- a/check-wait-label/main.js
+++ b/check-wait-label/main.js
@@ -1,6 +1,6 @@
 const core = require('@actions/core');
 const { context, GitHub } = require('@actions/github');
-const { getPrTime, applyLabel, removeLabel, getPrIds } = require("./utils");
+const { getPrTime, applyLabel, removeLabel, getPrIds, getWeekendDaysCount } = require("./utils");
 
 async function run() {
   try {
@@ -18,7 +18,9 @@ async function run() {
       let number = prs[i]
       let prTime = await getPrTime(octokit, repo, number)
       let nowTime = Date.now()
-      let timeWaited = (nowTime - prTime) / 24 / 60 / 60 / 1000
+      let timeElapsed = (nowTime - prTime) / 24 / 60 / 60 / 1000
+      let numWeekend = getWeekendDaysCount(prTime, nowTime)
+      let timeWaited = timeElapsed - numWeekend
 
       if (timeWaited - waitTime >= 0) {
         await applyLabel(octokit, repo, number, doneLabel)

--- a/check-wait-label/utils.js
+++ b/check-wait-label/utils.js
@@ -12,7 +12,8 @@ async function getPrTime(octokit, repo, issue_number) {
     ...repo,
     issue_number
   });
-  return Date.parse(issue.created_at);
+	let create_time = new Date(issue.created_at)
+  return create_time
 }
 
 async function removeLabel(octokit, repo, issue_number, oldLabel) {

--- a/check-wait-label/utils.js
+++ b/check-wait-label/utils.js
@@ -38,10 +38,25 @@ async function applyLabel(octokit, repo, issue_number, newLabel) {
 	})
 }
 
+function getWeekendDaysCount(startDate, endDate) {
+  let count = 0;
+  let curDate = startDate;
+  while (curDate <= endDate) {
+    var dayOfWeek = curDate.getDay();
+    if ((dayOfWeek == 6) || (dayOfWeek == 0)) {
+		  count++
+		}
+
+		curDate.setDate(curDate.getDate() + 1);
+  }
+  return count;
+}
+
 
 module.exports = {
 	getPrTime,
 	applyLabel,
 	removeLabel,
-	getPrIds
+	getPrIds,
+	getWeekendDaysCount
 }


### PR DESCRIPTION
When calculating the wait time of a PR, ignore weekend days in the calculation.