### PR TITLE
add assignee to issues

### DIFF
--- a/check-website-up/index.js
+++ b/check-website-up/index.js
@@ -51,7 +51,8 @@ async function openOrUpdateIssue(website, err, octokit, repo) {
     await octokit.issues.create({
       ...repo,
       title,
-      body: err
+      body: err,
+      assignee: "tdivoll"
     })
     console.log(`Opened issue`)
   }


### PR DESCRIPTION
This PR is to add an assignee to issues when websites are down. For now, I put my own user as a test. Ideally, emails would go to ccv-bot and then if possible, ccv-bot could send notifications to a Slack channel.