### PR TITLE
add ability to notify slack channel via webhook

### DIFF
--- a/check-website-up/README.md
+++ b/check-website-up/README.md
@@ -43,3 +43,36 @@ jobs:
           website: ${{ matrix.website }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 ```
+
+
+If your Slack Channel has registered an incoming webhook, you can optioanlly pass that along to the this action in order to receive a Slack alert in your team's channel. Your incoming webhook must be registered as a secret in your GitHub repo. 
+
+Note:  If your site runs behind Brown's firewall, you will need to deploy the action on a self-hosted runner. 
+
+## Example `workflow.yml`
+
+```yaml
+name: "Monitor QA / PROD XNAT"
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'  
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: self-hosted
+    strategy:
+      matrix:
+        url: ["https://xnat.bnc.brown.edu", "https://qa-xnat.bnc.brown.edu"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check ${{ matrix.url }}
+        uses: brown-ccv/gh-actions/check-website-up@main
+        with:
+          website: ${{ matrix.url }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+```

--- a/check-website-up/README.md
+++ b/check-website-up/README.md
@@ -45,7 +45,7 @@ jobs:
 ```
 
 
-If your Slack Channel has registered an incoming webhook, you can optioanlly pass that along to the this action in order to receive a Slack alert in your team's channel. Your incoming webhook must be registered as a secret in your GitHub repo. 
+If your Slack Channel has registered an incoming webhook, you can optionally pass that along to the this action in order to receive a Slack alert in your team's channel. Your incoming webhook must be registered as a secret in your GitHub repo. 
 
 Note:  If your site runs behind Brown's firewall, you will need to deploy the action on a self-hosted runner. 
 

--- a/check-website-up/action.yml
+++ b/check-website-up/action.yml
@@ -1,12 +1,19 @@
 name: 'Check Website'
-description: 'Are you running?'
+description: 'Checks if a website is reachable. Opens/closes GitHub issues and optionally notifies Slack.'
+
 inputs:
-  website:  # id of input
-    description: 'website url'
+  website:
+    description: 'The website URL to check'
     required: true
+
   github_token:
     description: 'secrets.GITHUB_TOKEN'
     required: true
+
+  slack_webhook_url:
+    description: 'Slack incoming webhook URL'
+    required: false
+
 runs:
   using: 'node12'
   main: "dist/index.js"

--- a/check-website-up/index.js
+++ b/check-website-up/index.js
@@ -7,7 +7,6 @@ async function run() {
     const repo = github.context.repo;
     const githubToken = core.getInput("GITHUB_TOKEN", {required: true});
     const website = core.getInput("website", {required: true});
-    const notifySlack = core.getInput("notify_slack") === 'true';
     const slackWebhook = notifySlack
       ? core.getInput("slack_webhook_url", { required: true })
       : null;
@@ -18,7 +17,7 @@ async function run() {
       const res = await axios.get(website);
       if (res.status >= 400) {
         console.log("Bad status returned from website");
-        if (notifySlack) {
+        if (slackWebhook) {
           await notifySlackChannel(website, res.statusText, slackWebhook)
         }
         await openOrUpdateIssue(website, res.statusText, octokit, repo);

--- a/check-website-up/index.js
+++ b/check-website-up/index.js
@@ -8,7 +8,7 @@ async function run() {
     const githubToken = core.getInput("GITHUB_TOKEN", {required: true});
     const website = core.getInput("website", {required: true});
     const slackWebhook = notifySlack
-      ? core.getInput("slack_webhook_url", { required: true })
+      ? core.getInput("slack_webhook_url", { required: false })
       : null;
 
     const octokit = github.getOctokit(githubToken);


### PR DESCRIPTION
## Add Option to Notify Slack Channel 

This PR gives the check-website GitHub Action optional Slack integration, allowing channels to receive alerts when a monitored website is down. This should maintain existing behavior (GitHub issue creation and closure) while adding support for Slack notifications via an incoming webhook.

I added a new input: `slack_webhook_url`, which should be added as a secret to the consumer action's repo.  A Slack Webhook can be obtained by creating an app (https://api.slack.com/apps), enabling incoming webhooks, and creating an incoming webhook for your desired channel.  

The calling action should look something like this:

```yaml
name: "Monitor QA / PROD XNAT"

on:
  schedule:
    - cron: '*/10 * * * *'  # every 10 minutes
  workflow_dispatch:

jobs:
  check:
    runs-on: self-hosted
    strategy:
      matrix:
        url: ["https://xnat.bnc.brown.edu", "https://qa-xnat.bnc.brown.edu"]
    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Check ${{ matrix.url }}
        uses: brown-ccv/gh-actions/check-website-up@main  
        with:
          website: ${{ matrix.url }}
          github_token: ${{ secrets.GITHUB_TOKEN }}
          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
``` 
