### PR TITLE
feat: add assignees to action

### DIFF
--- a/check-website-up/action.yml
+++ b/check-website-up/action.yml
@@ -14,6 +14,11 @@ inputs:
     description: 'Slack incoming webhook URL'
     required: false
 
+  assignees:
+    description: 'Comma-separated list of GitHub usernames to assign to the issue'
+    required: false
+    default: ''
+
 runs:
   using: 'node20'
   main: "dist/index.js"

--- a/check-website-up/index.js
+++ b/check-website-up/index.js
@@ -5,24 +5,24 @@ const axios = require('axios');
 async function run() {
   try {
     const repo = github.context.repo;
-    const githubToken = core.getInput("GITHUB_TOKEN", {required: true});
+    const githubToken = core.getInput("github_token", {required: true});
     const website = core.getInput("website", {required: true});
     const slackWebhook = core.getInput("slack_webhook_url", { required: false }) || null;
     const octokit = github.getOctokit(githubToken);
-
+    const assignees = core.getInput("assignees", { required: false }).split(",").map(a => a.trim()).filter(Boolean);
 
     console.log(`Checking if ${website} is up...`);
     console.log(`Using GitHub token: ${githubToken}`);
     console.log(`Using Slack webhook: ${slackWebhook}`);
-    
+
     try {
-      const res = await axios.get(website, { validateStatus: () => true });
+      const res = await axios.get(website, { validateStatus: () => true, timeout: 8000 });
       if (res.status >= 400) {
         console.log("Bad status returned from website");
         if (slackWebhook) {
           await notifySlackChannel(website, res.statusText, slackWebhook, repo)
         }
-        await openOrUpdateIssue(website, res.statusText, octokit, repo);
+        await openOrUpdateIssue(website, res.statusText, octokit, repo, assignees);
       } else {
         console.log("Successfully contacted website");
         await closeIssueIfOpen(website, octokit, repo);
@@ -33,7 +33,7 @@ async function run() {
         console.log(`Notifying Slack channel with webhook ${slackWebhook}`);
         await notifySlackChannel(website, err.message, slackWebhook, repo)
       }
-      await openOrUpdateIssue(website, err.message, octokit, repo);
+      await openOrUpdateIssue(website, err.message, octokit, repo, assignees);
     }
 
   } catch (error) {
@@ -55,7 +55,7 @@ async function notifySlackChannel(website, err, webhook, repo) {
 }
 
 async function checkForOpenIssue(website, repo) {
-  const githubToken = core.getInput("GITHUB_TOKEN", {required: true});
+  const githubToken = core.getInput("github_token", {required: true});
   const octokit = github.getOctokit(githubToken);
 
   const { data: issues } = await octokit.issues.listForRepo({
@@ -69,7 +69,7 @@ async function checkForOpenIssue(website, repo) {
   return open_issue
 }
 
-async function openOrUpdateIssue(website, err, octokit, repo) {
+async function openOrUpdateIssue(website, err, octokit, repo, assignees) {
   const open_issue = await checkForOpenIssue(website, repo)
 
   if (open_issue) {
@@ -86,7 +86,7 @@ async function openOrUpdateIssue(website, err, octokit, repo) {
       ...repo,
       title,
       body: err,
-      assignees: ["tdivoll", "fordmcdonald"]
+      assignees: assignees.length > 0 ? assignees : undefined
     })
     console.log(`Opened issue`)
   }


### PR DESCRIPTION
# Add Assignees Per Deployment

This input to the action will allow us to assign deployment owners to issues generated when site is down.

Here's an example use case of a consuming action:

 
```yaml
name: "Monitor Deployments"

on:
  schedule:
    - cron: '*/10 * * * *'  # every 10 minutes

jobs:
  check:
    runs-on: self-hosted
    strategy:
      matrix:
        include:
          - url: "https://xnat.bnc.brown.edu"
            assignees: ["fordmcdonald"]
          - url: "https://qa-xnat.bnc.brown.edu"
            assignees: ["fordmcdonald"]
    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Check ${{ matrix.url }}
        uses: brown-ccv/gh-actions/check-website-up@main  
        with:
          website: ${{ matrix.url }}
          github_token: ${{ secrets.GITHUB_TOKEN }}
          slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }} 
          assignees: ${{ join(matrix.assignees, ',') }}
```